### PR TITLE
tests: update SmartPGP-* applets

### DIFF
--- a/src/main/java/jcprofiler/instrumentation/Instrumenter.java
+++ b/src/main/java/jcprofiler/instrumentation/Instrumenter.java
@@ -183,7 +183,7 @@ public class Instrumenter {
             throw new UnsupportedOperationException("Usage of the default package detected! " +
                     "This is unsupported by the CAP converter.");
 
-        // Only JavaCard 3.0.1 and newer support multi package CAP files.
+        // Only JavaCard 3.1.0 and newer support multi package CAP files.
         // https://docs.oracle.com/en/java/javacard/3.1/guide/programming-multi-package-large-cap-files.html
         if (pkgs.size() != 1) {
             final JavaCardSDK.Version jcVersion = args.jcSDK.getVersion();

--- a/tests/test-data.json
+++ b/tests/test-data.json
@@ -803,14 +803,17 @@
             "name": "SmartPGP-applet",
             "repo": "https://github.com/ANSSI-FR/SmartPGP",
             "path": "src",
-            "jckit": "304",
-            "subtests": []
+            "jckit": "310r20210706",
+            "failure": {
+                "stopAfter": "compilation",
+                "reason": "Installation: CryptoException.NO_SUCH_ALGORITHM"
+            }
         },
         {
             "name": "SmartPGP-test_applet",
             "repo": "https://github.com/ANSSI-FR/SmartPGP",
             "path": "test_applet/src",
-            "jckit": "304",
+            "jckit": "310r20210706",
             "subtests": []
         },
         {


### PR DESCRIPTION
These applets now require JavaCard SDK 3.1 and SmartPGP-applet installation now fails due to usage of a crypto algorithm unsupported by jCardSim.